### PR TITLE
Add min-height to columns to fix layout issues

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -72,3 +72,7 @@ h1 {
 -moz-border-radius: 3px;
 border-radius: 3px;
 }
+
+.col-md-4 {
+  min-height: 415px;
+}


### PR DESCRIPTION
 Layout breaks between 991 and 1200px on gitly - quick fix is to give each .col-md-4 a min-height of 415px